### PR TITLE
Run git commands in parallel. Support for --debug and --verbose

### DIFF
--- a/tasks/gitInfo.js
+++ b/tasks/gitInfo.js
@@ -11,16 +11,7 @@
 module.exports = function(grunt) {
     grunt.registerTask('gitinfo', 'Your task description goes here.', function () {
         var done = this.async(),
-        gitinfo = {
-            local: {
-                branch : {
-                    current : {}
-                }
-            },
-            remote: {
-                origin: {}
-            }
-        },
+        gitinfo = {},
         commands = {
             'local.branch.current.name': ['rev-parse', '--abbrev-ref', 'HEAD'],
             'remote.origin.url': ['config', '--get-all', 'remote.origin.url'],
@@ -38,7 +29,17 @@ module.exports = function(grunt) {
                     if (err) {
                         console.warn("[gitinfo]: couldn't set config:", conf_key);
                     } else {
-                        gitinfo[conf_key] = result.stdout;
+                        var ref = gitinfo, keys = conf_key.split(".");
+                        for (var i = 0; i < keys.length-1; i++) {
+                          var key = keys[i];
+
+                          if (!ref[key]) {
+                            ref[key] = {};
+                          }
+
+                          ref = ref[key];
+                        }
+                        ref[keys.pop()] = result.stdout;
 
                         if (grunt.option("debug") || grunt.option("verbose")) {
                             console.log("[gitinfo]:", conf_key, "=", gitinfo[conf_key]);
@@ -51,6 +52,7 @@ module.exports = function(grunt) {
 
         function fin() {
             grunt.config.set('gitinfo', gitinfo);
+                console.log("[gitinfo]:", JSON.stringify(gitinfo, null, 2));
             done();
         }
 


### PR DESCRIPTION
Bugfix: I don't always have a remote.origin.url set in my project, grunt would just silently quit.
Feature: run all metadata inquiries in parallel.
Feature: --debug and --verbose output values.
