### PR TITLE
Make lodash, async, and getobject dependenices.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,16 @@
   "engines": {
     "node": ">= 0.8.0"
   },
+  "dependencies": {
+    "lodash": "~2.4.1",
+    "async": "~0.2.9",
+    "getobject": "~0.1.0"
+  },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1",
-    "lodash": "~2.4.1",
-    "async": "~0.2.9",
-    "getobject": "~0.1.0"
+    "grunt": "~0.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
These were specified as devDependencies but they're used by the task which means projects using this library would have to explicitly require lodash, async, and getobject.  Respecify-ing these libraries as dependencies.
