### PR TITLE
Extend existing gitinfo config

### DIFF
--- a/tasks/gitInfo.js
+++ b/tasks/gitInfo.js
@@ -66,7 +66,8 @@ module.exports = function (grunt) {
             },
 
             fin = function () {
-                grunt.config.set('gitinfo', gitinfo);
+                var merged = _.defaults(gitinfo, grunt.config.get('gitinfo'));
+                grunt.config.set('gitinfo', merged);
                 done();
             };
 


### PR DESCRIPTION
Instead of replacing, extend the existing gitinfo config. This way, users can add static information to their Grunt config that is git related but not available on a certain system (i.e. Jenkins).

**Consider the following scenario:**
On a Jenkins system I have a grunt task that, based on the git-flow prefix of the current branch triggers different actions. Since I have no access to the build system I can't configure git-flow on this system.
To help other users understand the available options and to have the git-flow configuration available on any system the config looks like this:

``` JavaScript
config.gitinfo = {
        local : {
            branch : {
                current : {
                    SHA              : "Current HEAD SHA",
                    shortSHA         : "Current HEAD short SHA",
                    name             : "Current branch name",
                    currentUser      : "Current git user",
                    lastCommitTime   : "Last commit time",
                    lastCommitAuthor : "Last commit author"
                }
            }
        },
        remote : {
            origin : {
                url : "Branch Url"
            }
        },
        gitflow: {
            branch: {
                master: "master",
                develop: "develop"
            },
            prefix: {
                feature: "feature/",
                release: "release/",
                hotfix: "hotfix/",
                versiontag: "Release-",
                support: "support/"
            }
        }
    };
```

The proposed change would replace the descriptive content for `local` and `remote` but leave the `gitflow` section intact.
