### PR TITLE
If no git tag is present, just use first 6 digits SHA1

### DIFF
--- a/tasks/gitInfo.js
+++ b/tasks/gitInfo.js
@@ -33,7 +33,7 @@ module.exports = function (grunt) {
                     'local.branch.current.currentUser'      : ['config', '--global', 'user.name'],
                     'local.branch.current.lastCommitTime'   : ['log', '--format="%ai"', '-n1', 'HEAD'],
                     'local.branch.current.lastCommitAuthor' : ['log', '--format="%aN"', '-n1', 'HEAD'],
-                    'local.branch.current.tag'              : ['describe', '--abbrev=0', '--exact-match'],
+                    'local.branch.current.tag'              : ['describe', '--always', '--tag'],
                     'remote.origin.url'                     : ['config', '--get-all', 'remote.origin.url']
                 }
             }, grunt.config.get('gitinfo')),


### PR DESCRIPTION
Fixes a bug causing gitinfo to fail if no tag is present in the git repository
