### PR TITLE
Add local.branch.current.tag to get the tag if any

### DIFF
--- a/tasks/gitInfo.js
+++ b/tasks/gitInfo.js
@@ -70,6 +70,10 @@ module.exports = function (grunt) {
 
             fin = function () {
                 var merged = _.defaults(gitinfo, grunt.config.get('gitinfo'));
+                merged.getTagOrBranchName = function() {
+                    return this.local.branch.current.tag ||
+                        this.local.branch.current.name;
+                };
                 grunt.config.set('gitinfo', merged);
                 done();
             };


### PR DESCRIPTION
First, thanks for this so very useful Grunt plugin! :-)

Then, here is a PR that adds the information `local.branch.current.tag` if the branch is a detached HEAD and if there is a tag for the current state.

Rationale: In all the projects we use we discovered that we need the tag to display it as the version number. Other people have the same need, see http://stackoverflow.com/questions/18659425/get-git-current-branch-tag-name
