### PR TITLE
Update dependencies

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
   },
   "dependencies": {
     "lodash": "~2.4.1",
-    "async": "~0.2.9",
+    "async": "~0.9.0",
     "getobject": "~0.1.0"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1"
+    "grunt": "^0.4.5",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-nodeunit": "^0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.5"
   },
   "keywords": [
     "gruntplugin"

--- a/tasks/gitInfo.js
+++ b/tasks/gitInfo.js
@@ -75,6 +75,6 @@ module.exports = function (grunt) {
 
         grunt.verbose.writeflags(config.options, 'config.options');
 
-        async.forEach(_.keys(config.commands), work, fin);
+        async.each(_.keys(config.commands), work, fin);
     });
 };


### PR DESCRIPTION
async : use `each` instead of deprecated `forEach`
        cf. https://github.com/caolan/async/commit/1fecb21940135b2ff647a93d1fc83df03b363714
JSHint: es5 is now enabled by default
