### PR TITLE
added local.tag.current.name property

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ The resulting `gitinfo` object has the following structure:
 ```js
 {
     local : {
+        tag : {
+            current : {
+                name              : "Current tag name (if not extact match tag then empty)",
+            }
+        },
         branch : {
             current : {
                 SHA               : "Current HEAD SHA",

--- a/tasks/gitInfo.js
+++ b/tasks/gitInfo.js
@@ -27,6 +27,7 @@ module.exports = function (grunt) {
                     cwd: null
                 },
                 commands : {
+                    'local.tag.current.name'                 : ['describe', '--tags', '--exact-match'],
                     'local.branch.current.name'              : ['rev-parse', '--abbrev-ref', 'HEAD'],
                     'local.branch.current.SHA'               : ['rev-parse', 'HEAD'],
                     'local.branch.current.shortSHA'          : ['rev-parse', '--short', 'HEAD'],
@@ -54,6 +55,7 @@ module.exports = function (grunt) {
                     function (err, result) {
                         if (err) {
                             grunt.log.debug("Couldn't set config:", conf_key);
+                            getobject.set(gitinfo, conf_key, "");
                         } else {
                             getobject.set(gitinfo, conf_key, result.stdout);
 


### PR DESCRIPTION
Hello,

i'm using grunt-gitinfo for the release process of a grunt project.
And i need to have the information of the current tag or branch.
[see this stackoverflow](http://stackoverflow.com/questions/18659425/get-git-current-branch-tag-name) for git command details.

Thanks
