### PR TITLE
Fix using author-date and author-name instead of commit-date and commit-name

### DIFF
--- a/tasks/gitInfo.js
+++ b/tasks/gitInfo.js
@@ -31,9 +31,9 @@ module.exports = function (grunt) {
                     'local.branch.current.SHA'               : ['rev-parse', 'HEAD'],
                     'local.branch.current.shortSHA'          : ['rev-parse', '--short', 'HEAD'],
                     'local.branch.current.currentUser'       : ['config', '--global', 'user.name'],
-                    'local.branch.current.lastCommitTime'    : ['log', '--format="%ai"', '-n1', 'HEAD'],
+                    'local.branch.current.lastCommitTime'    : ['log', '--format="%ci"', '-n1', 'HEAD'],
                     'local.branch.current.lastCommitMessage' : ['log', '--format="%B"', '-n1', 'HEAD'],
-                    'local.branch.current.lastCommitAuthor'  : ['log', '--format="%aN"', '-n1', 'HEAD'],
+                    'local.branch.current.lastCommitAuthor'  : ['log', '--format="%cN"', '-n1', 'HEAD'],
                     'local.branch.current.lastCommitNumber'  : ['rev-list', '--count', 'HEAD'],
                     'remote.origin.url'                      : ['config', '--get-all', 'remote.origin.url']
                 }


### PR DESCRIPTION
When retrieving the date of the last commit the author-time is taken not the commit-time. This may be confusing when cherry-picking a commit. Same goes for the committer-name. This pull request is one possibility to fix it. Another would be to create a new command that takes the commit-time. Based on the current name of the command (local.branch.current.lastCommitTime) I expected the commit-time and not the author-time.