### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-nodeunit": "^0.4.1"
   },
-  "peerDependencies": {
-    "grunt": ">=0.4.0"
-  },
   "keywords": [
     "gruntplugin"
   ]


### PR DESCRIPTION
peerinvalid Peer grunt-gitinfo@0.1.8 wants grunt@>=0.4.0

This happens with npm 1.3.4

```peerinvalid Peer grunt-gitinfo@0.1.8 wants grunt@>=0.4.0```

A similar issue happens here:

https://github.com/karma-runner/grunt-karma/issues/185

See also:

https://github.com/ActivearkJWT/grunt-size-report/pull/5/commits/32bc2bc6f42b27852cb9c127a869c04bbdb2fe1a


