### PR TITLE
Display error when it occurs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-gitinfo",
   "description": "Get Git info from a working copy and populate grunt.config with the data",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "homepage": "https://github.com/damkraw/grunt-gitinfo",
   "author": {
     "name": "Damian Krawczyk",

--- a/tasks/gitInfo.js
+++ b/tasks/gitInfo.js
@@ -53,6 +53,7 @@ module.exports = function (grunt) {
                     },
                     function (err, result) {
                         if (err) {
+                            grunt.log.debug("Error", err);
                             grunt.log.debug("Couldn't set config:", conf_key);
                         } else {
                             getobject.set(gitinfo, conf_key, result.stdout);


### PR DESCRIPTION
Display error when it occurs (eg. wrong command). Otherwise it's very hard to find out what went wrong.